### PR TITLE
Remove static option from brew install in readme - CGO requires this

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Having installed go with proper [path](http://golang.org/doc/code.html#GOPATH), 
 
 ```
 brew tap homebrew/versions
-brew install --build-bottle --static glfw3
+brew install glfw3
 brew install glew
 ```
 


### PR DESCRIPTION
Removing that static option so that no one else on a mac makes that mistake
